### PR TITLE
allow for custom http.url attribute to be specified; cleaned up tests

### DIFF
--- a/http.go
+++ b/http.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	// UrlAttribute allows a custom url to be specified
-	UrlAttribute = "http.url"
+	// URLAttribute allows a custom url to be specified
+	URLAttribute = "http.url"
 )
 
 // httpRequest – Information about an http request.
@@ -93,7 +93,7 @@ func makeHttp(attributes map[string]interface{}) (map[string]interface{}, *httpR
 		case ochttp.StatusCodeAttribute:
 			http.Response.Status, _ = value.(int64)
 
-		case UrlAttribute:
+		case URLAttribute:
 			http.Request.URL, _ = value.(string)
 
 		default:

--- a/http.go
+++ b/http.go
@@ -18,6 +18,11 @@ import (
 	"go.opencensus.io/plugin/ochttp"
 )
 
+const (
+	// UrlAttribute allows a custom url to be specified
+	UrlAttribute = "http.url"
+)
+
 // httpRequest – Information about an http request.
 type httpRequest struct {
 	// Method – The request method. For example, GET.
@@ -66,6 +71,7 @@ type httpReqResp struct {
 func makeHttp(attributes map[string]interface{}) (map[string]interface{}, *httpReqResp, string) {
 	var (
 		host     string
+		path     string
 		http     httpReqResp
 		filtered = map[string]interface{}{}
 	)
@@ -74,6 +80,9 @@ func makeHttp(attributes map[string]interface{}) (map[string]interface{}, *httpR
 		switch key {
 		case ochttp.HostAttribute:
 			host, _ = value.(string)
+
+		case ochttp.PathAttribute:
+			path, _ = value.(string)
 
 		case ochttp.MethodAttribute:
 			http.Request.Method, _ = value.(string)
@@ -84,9 +93,16 @@ func makeHttp(attributes map[string]interface{}) (map[string]interface{}, *httpR
 		case ochttp.StatusCodeAttribute:
 			http.Response.Status, _ = value.(int64)
 
+		case UrlAttribute:
+			http.Request.URL, _ = value.(string)
+
 		default:
 			filtered[key] = value
 		}
+	}
+
+	if http.Request.URL == "" {
+		http.Request.URL = host + path
 	}
 
 	if len(filtered) == len(attributes) {

--- a/http.go
+++ b/http.go
@@ -18,9 +18,6 @@ import (
 	"go.opencensus.io/plugin/ochttp"
 )
 
-// URLAttribute allows a custom url to be specified
-const URLAttribute = "http.url"
-
 // httpRequest – Information about an http request.
 type httpRequest struct {
 	// Method – The request method. For example, GET.
@@ -66,22 +63,14 @@ type httpReqResp struct {
 	Response httpResponse `json:"response"`
 }
 
-func makeHttp(attributes map[string]interface{}) (map[string]interface{}, *httpReqResp, string) {
+func makeHttp(spanName string, attributes map[string]interface{}) (map[string]interface{}, *httpReqResp) {
 	var (
-		host     string
-		path     string
 		http     httpReqResp
 		filtered = map[string]interface{}{}
 	)
 
 	for key, value := range attributes {
 		switch key {
-		case ochttp.HostAttribute:
-			host, _ = value.(string)
-
-		case ochttp.PathAttribute:
-			path, _ = value.(string)
-
 		case ochttp.MethodAttribute:
 			http.Request.Method, _ = value.(string)
 
@@ -91,21 +80,16 @@ func makeHttp(attributes map[string]interface{}) (map[string]interface{}, *httpR
 		case ochttp.StatusCodeAttribute:
 			http.Response.Status, _ = value.(int64)
 
-		case URLAttribute:
-			http.Request.URL, _ = value.(string)
-
 		default:
 			filtered[key] = value
 		}
 	}
 
-	if http.Request.URL == "" {
-		http.Request.URL = host + path
-	}
+	http.Request.URL = spanName
 
 	if len(filtered) == len(attributes) {
-		return attributes, nil, ""
+		return attributes, nil
 	}
 
-	return filtered, &http, host
+	return filtered, &http
 }

--- a/http.go
+++ b/http.go
@@ -18,10 +18,8 @@ import (
 	"go.opencensus.io/plugin/ochttp"
 )
 
-const (
-	// URLAttribute allows a custom url to be specified
-	URLAttribute = "http.url"
-)
+// URLAttribute allows a custom url to be specified
+const URLAttribute = "http.url"
 
 // httpRequest – Information about an http request.
 type httpRequest struct {

--- a/http_test.go
+++ b/http_test.go
@@ -97,7 +97,7 @@ func TestHttp(t *testing.T) {
 		t.Fatalf("unable to decode content, %v", err)
 	}
 
-	if got, want := content.Name, host; got != want {
+	if got, want := content.Name, path; got != want {
 		t.Errorf("got %v; want %v", got, want)
 	}
 	if got, want := content.Http.Request.Method, http.MethodGet; got != want {
@@ -106,7 +106,7 @@ func TestHttp(t *testing.T) {
 	if got, want := content.Http.Request.UserAgent, userAgent; got != want {
 		t.Errorf("got %v; want %v", got, want)
 	}
-	if got, want := content.Http.Request.URL, host+path; got != want {
+	if got, want := content.Http.Request.URL, path; got != want {
 		t.Errorf("got %v; want %v", got, want)
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -97,16 +97,16 @@ func TestHttp(t *testing.T) {
 		t.Fatalf("unable to decode content, %v", err)
 	}
 
-	if want := host; want != content.Name {
-		t.Errorf("want %v; got %v", want, content.Name)
+	if got, want := content.Name, host; got != want {
+		t.Errorf("got %v; want %v", got, want)
 	}
-	if want := http.MethodGet; want != content.Http.Request.Method {
-		t.Errorf("want %v; got %v", want, content.Http.Request.Method)
+	if got, want := content.Http.Request.Method, http.MethodGet; got != want {
+		t.Errorf("got %v; want %v", got, want)
 	}
-	if want := userAgent; want != content.Http.Request.UserAgent {
-		t.Errorf("want %v; got %v", want, content.Http.Request.UserAgent)
+	if got, want := content.Http.Request.UserAgent, userAgent; got != want {
+		t.Errorf("got %v; want %v", got, want)
 	}
-	if want := host + path; want != content.Http.Request.URL {
-		t.Errorf("want %v; got %v", want, content.Http.Request.URL)
+	if got, want := content.Http.Request.URL, host+path; got != want {
+		t.Errorf("got %v; want %v", got, want)
 	}
 }

--- a/segment.go
+++ b/segment.go
@@ -373,16 +373,13 @@ func rawSegment(span *trace.SpanData) segment {
 		startTime               = float64(startMicros) / 1e6
 		endMicros               = span.EndTime.UnixNano() / int64(time.Microsecond)
 		endTime                 = float64(endMicros) / 1e6
-		filtered, http, host    = makeHttp(span.Attributes)
+		filtered, http          = makeHttp(span.Name, span.Attributes)
 		isError, isFault, cause = makeCause(span.Status)
 		annotations             = makeAnnotations(span.Annotations, filtered)
 		name                    = fixSegmentName(span.Name)
 		namespace               string
 	)
 
-	if host != "" {
-		name = host
-	}
 	if span.HasRemoteParent {
 		namespace = "remote"
 	}


### PR DESCRIPTION
A custom `http.url` is useful to support new rpc formats like graphql where an entire site's api might be service by `POST /api/graphql`.  This is double true for aws x-ray since the url is so prevalent in its reporting.