### PR TITLE
Wait for on export

### DIFF
--- a/xray.go
+++ b/xray.go
@@ -321,8 +321,8 @@ func (e *Exporter) publish(spans []*trace.SpanData) {
 		_, err := e.api.PutTraceSegments(&input)
 		if err == nil {
 			if e.onExport != nil {
+				e.wg.Add(len(traceIDs))
 				for _, traceID := range traceIDs {
-					e.wg.Add(1)
 					go func() {
 						defer e.wg.Done()
 						e.onExport(OnExport{TraceID: traceID})


### PR DESCRIPTION
* onExport is now included in the set of goroutines managed by wg
* moved calls of wg.Add and wg.Done closer together so the relationship is clearer

Resolves issue, https://github.com/census-ecosystem/opencensus-go-exporter-aws/issues/19
