### PR TITLE
Don't send empty traces.

### DIFF
--- a/xray.go
+++ b/xray.go
@@ -342,6 +342,9 @@ func (e *Exporter) publish(spans []*trace.SpanData) {
 	var (
 		input, traceIDs = e.makeInput(spans)
 	)
+	if len(input.TraceSegmentDocuments) == 0 {
+		return
+	}
 
 	for attempt := 0; attempt < 3; attempt++ {
 		_, err := e.api.PutTraceSegments(&input)


### PR DESCRIPTION
X-Ray disallows traces with empty segment lists. The list can be empty due to every span matching the blacklist.