### PR TITLE
added support for go 1.11 modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module contrib.go.opencensus.io/exporter/aws
+
+require (
+	github.com/aws/aws-sdk-go v1.15.27
+	go.opencensus.io v0.15.0
+)


### PR DESCRIPTION
Added go.mod file for go 1.11 module support.  Opting to leave out the `go.sum` file for now.