### PR TITLE
cleaning up package imports

### DIFF
--- a/examples/xray/main.go
+++ b/examples/xray/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/census-instrumentation/opencensus-go-exporter-aws"
+	"contrib.go.opencensus.io/exporter/aws"
 	"go.opencensus.io/trace"
 )
 

--- a/http_propagation_test.go
+++ b/http_propagation_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/header"
 	"go.opencensus.io/trace"
 )
 
@@ -68,7 +67,7 @@ func TestSpanContextFromRequest(t *testing.T) {
 	t.Run("traceID only with root prefix", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
 		amazonTraceID := convertToAmazonTraceID(traceID)
-		req.Header.Set(httpHeader, header.RootPrefix+amazonTraceID)
+		req.Header.Set(httpHeader, prefixRoot+amazonTraceID)
 
 		sc, ok := format.SpanContextFromRequest(req)
 		if !ok {


### PR DESCRIPTION
* removing unnecessary github.com/aws/aws-xray-sdk-go/header
* renaming github.com/census-instrumentation/opencensus-go-exporter-aws -> contrib.go.opencensus.io/exporter/aws