### PR TITLE
Add support for segment naming

### DIFF
--- a/segment.go
+++ b/segment.go
@@ -382,7 +382,7 @@ func fixAnnotationKey(key string) string {
 	return key
 }
 
-func rawSegment(span *trace.SpanData) segment {
+func rawSegment(name string, span *trace.SpanData) segment {
 	var (
 		traceID                 = convertToAmazonTraceID(span.TraceID)
 		startMicros             = span.StartTime.UnixNano() / int64(time.Microsecond)
@@ -392,10 +392,12 @@ func rawSegment(span *trace.SpanData) segment {
 		filtered, http          = makeHttp(span.Name, span.Code, span.Attributes)
 		isError, isFault, cause = makeCause(span.Status)
 		annotations             = makeAnnotations(span.Annotations, filtered)
-		name                    = fixSegmentName(span.Name)
 		namespace               string
 	)
 
+	if name == "" {
+		name = fixSegmentName(span.Name)
+	}
 	if span.HasRemoteParent {
 		namespace = "remote"
 	}

--- a/xray_test.go
+++ b/xray_test.go
@@ -288,6 +288,18 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("WithServiceName", func(t *testing.T) {
+		name := "test"
+		config, err := buildConfig(WithServiceName(name), WithRegion("blah"))
+		if err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+
+		if name != config.name {
+			t.Fatalf("want %v, got %v", name, config.name)
+		}
+	})
+
 	t.Run("WithVersion", func(t *testing.T) {
 		const version = "latest"
 		config, err := buildConfig(WithVersion(version), WithRegion("blah"))
@@ -333,6 +345,7 @@ func TestOptions(t *testing.T) {
 		var (
 			version   = "blah"
 			origin    = OriginEB
+			name      = "test"
 			exported  = make(chan struct{})
 			api       = &testSegments{ch: make(chan segment, 1)}
 			blacklist = []*regexp.Regexp{regexp.MustCompile("nospan")}
@@ -346,6 +359,7 @@ func TestOptions(t *testing.T) {
 			exporter, _ = NewExporter(
 				WithAPI(api),
 				WithOrigin(origin),
+				WithServiceName(name),
 				WithVersion(version),
 				WithOnExport(onExport),
 				WithInterval(100*time.Millisecond),
@@ -370,6 +384,9 @@ func TestOptions(t *testing.T) {
 		// Then
 		select {
 		case segment := <-api.ch:
+			if name != segment.Name {
+				t.Errorf("expected %v; got %v", name, segment.Name)
+			}
 			if segment.Service == nil || segment.Service.Version != version {
 				t.Errorf("expected %v; got %#v", version, segment.Service)
 			}


### PR DESCRIPTION
Adding WithServiceName exporter option which will be used to name
exported segments. Service name can also be defined via
AWS_XRAY_TRACING_NAME enviroment which takes precedence over
the above settings.