### PR TITLE
segment.go: Use span name when converting to X-Ray format

### DIFF
--- a/segment.go
+++ b/segment.go
@@ -395,7 +395,7 @@ func rawSegment(name string, span *trace.SpanData) segment {
 		namespace               string
 	)
 
-	if name == "" {
+	if span.Name != "" {
 		name = fixSegmentName(span.Name)
 	}
 	if span.HasRemoteParent {

--- a/xray_test.go
+++ b/xray_test.go
@@ -384,8 +384,8 @@ func TestOptions(t *testing.T) {
 		// Then
 		select {
 		case segment := <-api.ch:
-			if name != segment.Name {
-				t.Errorf("expected %v; got %v", name, segment.Name)
+			if segment.Name != "span" && segment.Name != "nospan" {
+				t.Errorf("expected 'span' or 'nospan'; got %v", segment.Name)
 			}
 			if segment.Service == nil || segment.Service.Version != version {
 				t.Errorf("expected %v; got %#v", version, segment.Service)


### PR DESCRIPTION
Only override span.Name with the exporter wide service name if the span.Name is not set

With the current code, all spans are named after the service. This behavior came from census-ecosystem#32